### PR TITLE
Issue6商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all
-    @items = Item.order("created_at DESC")
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all
     @items = Item.order('created_at DESC')
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    # @items = Item.order("created_at DESC")
+    @items = Item.all
+    @items = Item.order("created_at DESC")
   end
 
   def new

--- a/app/models/item_shipping_fee_status.rb
+++ b/app/models/item_shipping_fee_status.rb
@@ -1,7 +1,7 @@
 class ItemShippingFeeStatus < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
-    { id: 2, name: '着払い(購入者負担' },
+    { id: 2, name: '着払い(購入者負担)' },
     { id: 3, name: '送料込み(出品者負担)' }
   ]
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -118,7 +118,6 @@
   </div>
   <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <div class="subtitle" >
@@ -126,14 +125,14 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%#div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
@@ -141,10 +140,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.item_price %>円<br><%= item.item_shipping_fee_status.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +152,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% unless @items.any? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,11 +172,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
-  <%# /商品一覧 %>
 </div>
  <% if user_signed_in? %>
   <%= link_to(new_item_path, class: 'purchase-btn') do %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe Item, type: :model do
       it 'item_nameが41文字以上の場合保存できない' do
         @item.item_name = Faker::Lorem.characters(number: 41)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item name is too long (maximum is 40 characters)")
+        expect(@item.errors.full_messages).to include('Item name is too long (maximum is 40 characters)')
       end
       it 'item_infoが1001文字以上の場合保存できない' do
         @item.item_info = Faker::Lorem.characters(number: 1001)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item info is too long (maximum is 1000 characters)")
+        expect(@item.errors.full_messages).to include('Item info is too long (maximum is 1000 characters)')
       end
 
       it 'item_category_idが1の場合保存できない' do


### PR DESCRIPTION
#WHAT
商品一覧表示機能を実素

#WHY
・出品された商品を表示する為
・ログインの有無に関係なく表示させて誰でも見られるようにする為

商品のデータがない場合は、ダミー商品が表示されているGIF : https://gyazo.com/51decbeffcc72508c49e4869ade1d5a7
商品のデータがある場合は、商品が一覧で表示されているGIF : https://gyazo.com/78985e38c55a7802341d12178d92182a